### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: java
 cache:
   directories:
   - $HOME/.m2
-script:
+install:
   - gradle build
+script:
   - ./compile.sh tests/bracket-access.lj && ./test.sh
   - ./compile.sh tests/comp/3np1for.lj && ./test.sh
   - ./compile.sh tests/comp/3np1while.lj && ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: java
+cache:
+  directories:
+  - $HOME/.m2
+script:
+  - gradle build
+  - ./compile.sh tests/bracket-access.lj && ./test.sh
+  - ./compile.sh tests/comp/3np1for.lj && ./test.sh
+  - ./compile.sh tests/comp/3np1while.lj && ./test.sh
+  - ./compile.sh tests/comp/different.lj && ./test.sh
+  - ./compile.sh tests/comp/oddgnome.lj && ./test.sh
+  - ./compile.sh tests/collections.lj && ./test.sh
+  - ./compile.sh tests/demo.lj && ./test.sh
+  - ./compile.sh tests/dog.lj && ./test.sh
+  - ./compile.sh tests/eqtests.lj && ./test.sh
+  - ./compile.sh tests/fact.lj && ./test.sh
+  - ./compile.sh tests/forloop.lj && ./test.sh
+  - ./compile.sh tests/format.lj && ./test.sh
+  - ./compile.sh tests/fp.lj && ./test.sh
+  - ./compile.sh tests/oop.lj && ./test.sh
+  - ./compile.sh tests/precedence.lj && ./test.sh
+  - ./compile.sh tests/quicksort.lj && ./test.sh
+  - ./compile.sh tests/shadow.lj && ./test.sh
+  - ./compile.sh tests/type-inference.lj && ./test.sh
+  - ./compile.sh tests/unit-test.lj && ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/JMU-CS/less-java.svg?branch=master)](https://travis-ci.org/JMU-CS/less-java)
+
 # A language to introduce students to programming
 Get gradle aliases from my .dotfiles repo: [Gradle Aliases](https://github.com/Zamua/.dotfiles/blob/master/gradle-aliases.sh)
 


### PR DESCRIPTION
Not sure how serious you are about #33, but I was playing around with it to see what happened. This adds a pretty basic .travis-ci.yml and runs a few known-good test cases just to get started.

Build status would look like this: https://travis-ci.org/ripleymj/less-java/builds and someone would need to register JMU-CS with Travis.