### PR TITLE
Add Gradle wrapper support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
   - $HOME/.m2
 install:
-  - gradle build
+  - ./gradlew build
 script:
   - ./compile.sh tests/bracket-access.lj && ./test.sh
   - ./compile.sh tests/comp/3np1for.lj && ./test.sh

--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-gradle -q run -Ptestfile=${1}
+GRADLE_WRAPPER="./gradlew"
+
+"$GRADLE_WRAPPER" -q run -Ptestfile=${1}
 

--- a/distro.sh
+++ b/distro.sh
@@ -1,3 +1,6 @@
-#!/bin/bash
-gradle fatJar
+#!/usr/bin/env bash
+
+GRADLE_WRAPPER="./gradlew"
+
+"$GRADLE_WRAPPER" fatJar
 cp build/libs/*-all.jar distribution/lj.jar


### PR DESCRIPTION
`#!/bin/bash` was also replaced with `#!/usr/bin/env bash` because on some systems (like mine) bash doesn't exist in `/bin`.

Closes #36 