### PR TITLE
Test against multiple current Java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
+jdk:
+  - openjdk8
+  - openjdk10
+  - openjdk11
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
Testing against more than one version of Java allows for ensuring
that there aren't any regressions in versions of Java that may be
used by end usres.

Java 8 is chosen because it is still fairly common and seems to be
what was used primarily in the past. Java 11 is the currently-supported
version. Java 10 is chosen because it is what the CS lab machines
used in the spring.

This will fire off three concurrent Travis builds for each commit, one build
for each version of Java.