### PR TITLE
Fix JUnit Testing Script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,4 +7,4 @@
 # The grep -v filter removes lines that are unnecessary or potentially
 #    confusing to an end user.
 java -jar libs/junit-platform-console-standalone-1.4.2.jar --class-path ".:generated" --include-classname='.*' --disable-banner --scan-class-path \
-    | grep -v -e '\[.*containers.*\]' -e 'JUnit Vintage'
+    | grep -v -e '\[.*containers.*\]' -e 'JUnit Vintage' -e 'Test run finished after'

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,14 @@
 # --include-classname allows the name to be anything
 # --disable-banner disables the banner asking contributing to JUnit
 # --scan-class-path checks the full classpath for tests
+# Get the output but do not print it yet
+test_output="$(java -jar libs/junit-platform-console-standalone-1.4.2.jar --class-path ".:generated" --include-classname='.*' --disable-banner --scan-class-path)"
+# Preserve  the exit code of the tests
+test_status="$?"
+
 # The grep -v filter removes lines that are unnecessary or potentially
 #    confusing to an end user.
-java -jar libs/junit-platform-console-standalone-1.4.2.jar --class-path ".:generated" --include-classname='.*' --disable-banner --scan-class-path \
-    | grep -v -e '\[.*containers.*\]' -e 'JUnit Vintage' -e 'Test run finished after'
+echo "$test_output" | grep -v -e '\[.*containers.*\]' -e 'JUnit Vintage' -e 'Test run finished after'
+
+# Ensure the exit code from the tests is the exit code of the script
+exit "$test_status"

--- a/tests/comp/outputs/3np1for_test.exp
+++ b/tests/comp/outputs/3np1for_test.exp
@@ -6,7 +6,6 @@
 [36m│     ├─[0m [34mtest2()[0m [32m✔[0m
 [36m│     └─[0m [34mtest3()[0m [32m✔[0m
 
-Test run finished after 99 ms
 [         4 tests found           ]
 [         0 tests skipped         ]
 [         4 tests started         ]

--- a/tests/comp/outputs/3np1while_test.exp
+++ b/tests/comp/outputs/3np1while_test.exp
@@ -8,7 +8,6 @@
 [36m│     ├─[0m [34mtest4()[0m [32m✔[0m
 [36m│     └─[0m [34mtest5()[0m [32m✔[0m
 
-Test run finished after 119 ms
 [         6 tests found           ]
 [         0 tests skipped         ]
 [         6 tests started         ]

--- a/tests/comp/outputs/abracadabra_test.exp
+++ b/tests/comp/outputs/abracadabra_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 46 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/comp/outputs/different_test.exp
+++ b/tests/comp/outputs/different_test.exp
@@ -6,7 +6,6 @@
 [36m│     ├─[0m [34mtest2()[0m [32m✔[0m
 [36m│     └─[0m [34mtest3()[0m [32m✔[0m
 
-Test run finished after 95 ms
 [         4 tests found           ]
 [         0 tests skipped         ]
 [         4 tests started         ]

--- a/tests/comp/outputs/fizzbuzz_test.exp
+++ b/tests/comp/outputs/fizzbuzz_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 52 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/comp/outputs/oddgnome_test.exp
+++ b/tests/comp/outputs/oddgnome_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 84 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/failing/outputs/add_test.exp
+++ b/tests/failing/outputs/add_test.exp
@@ -20,7 +20,6 @@ Failures (1):
        java.base/java.lang.reflect.Method.invoke(Method.java:566)
        [...]
 
-Test run finished after 87 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/failing/outputs/list_remove_test.exp
+++ b/tests/failing/outputs/list_remove_test.exp
@@ -20,7 +20,6 @@ Failures (1):
        java.base/java.lang.reflect.Method.invoke(Method.java:566)
        [...]
 
-Test run finished after 85 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/failing/outputs/z_test.exp
+++ b/tests/failing/outputs/z_test.exp
@@ -20,7 +20,6 @@ Failures (1):
        java.base/java.lang.reflect.Method.invoke(Method.java:566)
        [...]
 
-Test run finished after 117 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/io/outputs/add_test.exp
+++ b/tests/io/outputs/add_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 45 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/collections_test.exp
+++ b/tests/io/outputs/collections_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 47 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/for-loop_test.exp
+++ b/tests/io/outputs/for-loop_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 50 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/hello-world_test.exp
+++ b/tests/io/outputs/hello-world_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 46 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/input2_test.exp
+++ b/tests/io/outputs/input2_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 42 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/input_test.exp
+++ b/tests/io/outputs/input_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 49 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/print_test.exp
+++ b/tests/io/outputs/print_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 52 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/io/outputs/sum_test.exp
+++ b/tests/io/outputs/sum_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 60 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/outputs/bracket-access_test.exp
+++ b/tests/outputs/bracket-access_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 87 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/car_test.exp
+++ b/tests/outputs/car_test.exp
@@ -4,7 +4,6 @@
 [36m│     ├─[0m [34mtest0()[0m [32m✔[0m
 [36m│     └─[0m [34mtest1()[0m [32m✔[0m
 
-Test run finished after 98 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/outputs/collections_test.exp
+++ b/tests/outputs/collections_test.exp
@@ -31,7 +31,6 @@
 [36m│     ├─[0m [34mtest8()[0m [32m✔[0m
 [36m│     └─[0m [34mtest9()[0m [32m✔[0m
 
-Test run finished after 131 ms
 [        29 tests found           ]
 [         0 tests skipped         ]
 [        29 tests started         ]

--- a/tests/outputs/counterexample_test.exp
+++ b/tests/outputs/counterexample_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 96 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/demo_test.exp
+++ b/tests/outputs/demo_test.exp
@@ -35,7 +35,6 @@ p2 (0) is less than p1 (10)
 [36m│     ├─[0m [34mtest0()[0m [32m✔[0m
 [36m│     └─[0m [34mtest1()[0m [32m✔[0m
 
-Test run finished after 107 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/outputs/dog_test.exp
+++ b/tests/outputs/dog_test.exp
@@ -4,7 +4,6 @@
 [36m│     ├─[0m [34mtest0()[0m [32m✔[0m
 [36m│     └─[0m [34mtest1()[0m [32m✔[0m
 
-Test run finished after 105 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/outputs/eqtests_test.exp
+++ b/tests/outputs/eqtests_test.exp
@@ -10,7 +10,6 @@
 [36m│     ├─[0m [34mtest6()[0m [32m✔[0m
 [36m│     └─[0m [34mtest7()[0m [32m✔[0m
 
-Test run finished after 90 ms
 [         8 tests found           ]
 [         0 tests skipped         ]
 [         8 tests started         ]

--- a/tests/outputs/fact_test.exp
+++ b/tests/outputs/fact_test.exp
@@ -7,7 +7,6 @@
 [36m│     ├─[0m [34mtest3()[0m [32m✔[0m
 [36m│     └─[0m [34mtest4()[0m [32m✔[0m
 
-Test run finished after 106 ms
 [         5 tests found           ]
 [         0 tests skipped         ]
 [         5 tests started         ]

--- a/tests/outputs/forloop_test.exp
+++ b/tests/outputs/forloop_test.exp
@@ -4,7 +4,6 @@
 [36m│     ├─[0m [34mtest0()[0m [32m✔[0m
 [36m│     └─[0m [34mtest1()[0m [32m✔[0m
 
-Test run finished after 111 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/outputs/format_test.exp
+++ b/tests/outputs/format_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 83 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/fp_test.exp
+++ b/tests/outputs/fp_test.exp
@@ -4,7 +4,6 @@
 [36m│     ├─[0m [34mtest0()[0m [32m✔[0m
 [36m│     └─[0m [34mtest1()[0m [32m✔[0m
 
-Test run finished after 82 ms
 [         2 tests found           ]
 [         0 tests skipped         ]
 [         2 tests started         ]

--- a/tests/outputs/global_test.exp
+++ b/tests/outputs/global_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 41 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/outputs/oop_test.exp
+++ b/tests/outputs/oop_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 131 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/precedence_test.exp
+++ b/tests/outputs/precedence_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 87 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/primitive-numbers_test.exp
+++ b/tests/outputs/primitive-numbers_test.exp
@@ -38,7 +38,6 @@ Failures (2):
        java.base/java.lang.reflect.Method.invoke(Method.java:566)
        [...]
 
-Test run finished after 102 ms
 [         6 tests found           ]
 [         0 tests skipped         ]
 [         6 tests started         ]

--- a/tests/outputs/quicksort_test.exp
+++ b/tests/outputs/quicksort_test.exp
@@ -6,7 +6,6 @@
 [36m│     ├─[0m [34mtest2()[0m [32m✔[0m
 [36m│     └─[0m [34mtest3()[0m [32m✔[0m
 
-Test run finished after 88 ms
 [         4 tests found           ]
 [         0 tests skipped         ]
 [         4 tests started         ]

--- a/tests/outputs/shadow_test.exp
+++ b/tests/outputs/shadow_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 89 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/type-inference_test.exp
+++ b/tests/outputs/type-inference_test.exp
@@ -23,7 +23,6 @@
 [36m│     ├─[0m [34mtest8()[0m [32m✔[0m
 [36m│     └─[0m [34mtest9()[0m [32m✔[0m
 
-Test run finished after 126 ms
 [        21 tests found           ]
 [         0 tests skipped         ]
 [        21 tests started         ]

--- a/tests/outputs/unit-test_test.exp
+++ b/tests/outputs/unit-test_test.exp
@@ -3,7 +3,6 @@
 [36m│  └─[0m [36mMain[0m [32m✔[0m
 [36m│     └─[0m [34mtest0()[0m [32m✔[0m
 
-Test run finished after 126 ms
 [         1 tests found           ]
 [         0 tests skipped         ]
 [         1 tests started         ]

--- a/tests/outputs/unop_test.exp
+++ b/tests/outputs/unop_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 55 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/user-submitted/outputs/kyle_test.exp
+++ b/tests/user-submitted/outputs/kyle_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 56 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]

--- a/tests/user-submitted/outputs/payroll_test.exp
+++ b/tests/user-submitted/outputs/payroll_test.exp
@@ -1,7 +1,6 @@
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 
-Test run finished after 52 ms
 [         0 tests found           ]
 [         0 tests skipped         ]
 [         0 tests started         ]


### PR DESCRIPTION
As mentioned in #47, all expected outputs needed to be regenerated.

Further, the testing script needed to be modified to ensure that the exit code from the tests is used for the script.

Closes #47 