### PR TITLE
Basic OO support and purging type information between function instances

### DIFF
--- a/src/main/java/com/github/lessjava/LJCompiler.java
+++ b/src/main/java/com/github/lessjava/LJCompiler.java
@@ -96,6 +96,7 @@ public class LJCompiler {
         program.traverse(inferConstructors);
 
         do {
+            program.traverse(buildParentLinks); // Rebuild parent links in case we instantiated new functions
             StaticAnalysis.resetErrors();   // Remove errors found in old iterations
             program.traverse(buildSymbolTables);
             program.traverse(instantiateFunctions);

--- a/src/main/java/com/github/lessjava/types/ast/ASTAbstractFunction.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTAbstractFunction.java
@@ -67,6 +67,9 @@ public abstract class ASTAbstractFunction extends ASTNode {
         ASTFunction format = new ASTFunction("format", new HMTypeBase(BaseDataType.STR), null);
         libraryFunctions.add(format);
         specialCases.put(format.name, format);
+        ASTFunction printf = new ASTFunction("printf", new HMTypeBase(BaseDataType.VOID), null);
+        libraryFunctions.add(printf);
+        specialCases.put(printf.name, printf);
     }
 
     public static class Parameter {

--- a/src/main/java/com/github/lessjava/types/ast/ASTAssignment.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTAssignment.java
@@ -25,7 +25,11 @@ public class ASTAssignment extends ASTBinaryExpr {
     @Override
     public void traverse(ASTVisitor visitor) {
         visitor.preVisit(this);
-        variable.traverse(visitor);
+        if(this.memberAccess == null) {
+            variable.traverse(visitor);
+        } else {
+            memberAccess.traverse(visitor);
+        }
         value.traverse(visitor);
         visitor.postVisit(this);
     }

--- a/src/main/java/com/github/lessjava/types/ast/ASTMemberAccess.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTMemberAccess.java
@@ -1,13 +1,11 @@
 package com.github.lessjava.types.ast;
 
 public class ASTMemberAccess extends ASTExpression {
-    public String className;
-    public String referencedClassName;
+    public ASTVariable instance;
     public ASTVariable var;
 
-    public ASTMemberAccess(String className, String referencedClassName, ASTVariable var) {
-        this.className = className;
-        this.referencedClassName = referencedClassName;
+    public ASTMemberAccess(String className, ASTVariable var) {
+        this.instance = new ASTVariable(className);
         this.var = var;
     }
 
@@ -15,7 +13,7 @@ public class ASTMemberAccess extends ASTExpression {
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(String.format("%s.%s", className, var));
+        sb.append(String.format("%s.%s", instance.name, var));
 
         return sb.toString();
     }
@@ -23,6 +21,7 @@ public class ASTMemberAccess extends ASTExpression {
     @Override
     public void traverse(ASTVisitor visitor) {
         visitor.preVisit(this);
+        this.instance.traverse(visitor);
         this.var.traverse(visitor);
         visitor.postVisit(this);
     }

--- a/src/main/java/com/github/lessjava/types/inference/impl/HMTypeClass.java
+++ b/src/main/java/com/github/lessjava/types/inference/impl/HMTypeClass.java
@@ -14,11 +14,13 @@ public class HMTypeClass extends HMType {
     public HMTypeClass(String name, HashSet<String> methods) {
         this.name = name;
         this.methods = methods;
+        this.isConcrete = true;
     }
 
     public HMTypeClass(String name) {
         this.name = name;
         this.methods = new HashSet<>();
+        this.isConcrete = true;
     }
 
     public void addMethod(ASTFunction method) {

--- a/src/main/java/com/github/lessjava/visitor/impl/BuildParentLinks.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/BuildParentLinks.java
@@ -118,6 +118,9 @@ public class BuildParentLinks extends LJDefaultASTVisitor {
     public void preVisit(ASTAssignment node) {
         node.variable.setParent(node);
         node.value.setParent(node);
+        if(node.memberAccess != null) {
+            node.memberAccess.setParent(node);
+        }
     }
 
     @Override
@@ -200,6 +203,7 @@ public class BuildParentLinks extends LJDefaultASTVisitor {
 
     @Override
     public void preVisit(ASTMemberAccess node) {
+        node.instance.setParent(node);
         node.var.setParent(node);
     }
 

--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTConverter.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTConverter.java
@@ -672,16 +672,9 @@ public class LJASTConverter extends LJBaseListener {
         ASTMemberAccess memberAccess;
 
         String className = ctx.instance.getText();
-        String referencedClassName = className;
         ASTVariable var = (ASTVariable) parserASTMap.get(ctx.var());
 
-        if (className.equals("this")) {
-            referencedClassName = this.currentClassSignature.className;
-        } else if(className.equals("super")) {
-            referencedClassName = this.currentClassSignature.superName;
-        }
-
-        memberAccess = new ASTMemberAccess(className, referencedClassName, var);
+        memberAccess = new ASTMemberAccess(className, var);
         memberAccess.lineNumber = ctx.getStart().getLine();
 
         memberAccess.setDepth(ctx.depth());

--- a/src/main/java/com/github/lessjava/visitor/impl/LJDuplicateBlock.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJDuplicateBlock.java
@@ -1,0 +1,338 @@
+package com.github.lessjava.visitor.impl;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import com.github.lessjava.types.ast.ASTArgList;
+import com.github.lessjava.types.ast.ASTAssignment;
+import com.github.lessjava.types.ast.ASTBinaryExpr;
+import com.github.lessjava.types.ast.ASTBlock;
+import com.github.lessjava.types.ast.ASTBreak;
+import com.github.lessjava.types.ast.ASTConditional;
+import com.github.lessjava.types.ast.ASTContinue;
+import com.github.lessjava.types.ast.ASTEntry;
+import com.github.lessjava.types.ast.ASTExpression;
+import com.github.lessjava.types.ast.ASTForLoop;
+import com.github.lessjava.types.ast.ASTFunctionCall;
+import com.github.lessjava.types.ast.ASTList;
+import com.github.lessjava.types.ast.ASTLiteral;
+import com.github.lessjava.types.ast.ASTLocation;
+import com.github.lessjava.types.ast.ASTMap;
+import com.github.lessjava.types.ast.ASTMemberAccess;
+import com.github.lessjava.types.ast.ASTMethodCall;
+import com.github.lessjava.types.ast.ASTReturn;
+import com.github.lessjava.types.ast.ASTSet;
+import com.github.lessjava.types.ast.ASTStatement;
+import com.github.lessjava.types.ast.ASTUnaryExpr;
+import com.github.lessjava.types.ast.ASTVariable;
+import com.github.lessjava.types.ast.ASTVoidAssignment;
+import com.github.lessjava.types.ast.ASTVoidFunctionCall;
+import com.github.lessjava.types.ast.ASTVoidMethodCall;
+import com.github.lessjava.types.ast.ASTWhileLoop;
+import com.github.lessjava.types.inference.impl.HMTypeBase;
+import com.github.lessjava.visitor.LJDefaultASTVisitor;
+
+public class LJDuplicateBlock extends LJDefaultASTVisitor {
+
+    private Deque<ASTBlock> blocks;
+    private Deque<ASTStatement> statements;
+    private Deque<ASTExpression> expressions;
+    private ASTBlock lastCompletedBlock;
+
+    /**
+     * Returns a duplicated version of the given block. The duplicated block will have all type
+     * information erased, so that it can be retyped independent from the types calculated for the
+     * given block. Useful for instantiating functions, so that different parameter bindings don't
+     * cause issues.
+     * @param blockToDuplicate the block to be duplicated
+     * @return a copy of the given block that has type information erased
+     */
+    public ASTBlock duplicateBlock(ASTBlock blockToDuplicate) {
+        blocks = new ArrayDeque<>();
+        statements = new ArrayDeque<>();
+        expressions = new ArrayDeque<>();
+        blockToDuplicate.traverse(this);
+        return blocks.pop();
+    }
+
+    @Override
+    public void preVisit(ASTBreak node) {
+        ASTBreak breakCopy = new ASTBreak();
+        breakCopy.lineNumber = node.lineNumber;
+        statements.push(breakCopy);
+    }
+
+    @Override
+    public void postVisit(ASTBreak node) {
+        blocks.peek().statements.add(statements.pop());
+    }
+
+    @Override
+    public void preVisit(ASTConditional node) {
+        ASTConditional conditionalCopy = new ASTConditional(null, null);
+        conditionalCopy.lineNumber = node.lineNumber;
+        statements.push(conditionalCopy);
+    }
+
+    @Override
+    public void postVisit(ASTConditional node) {
+        ASTConditional conditionalCopy = (ASTConditional)statements.pop();
+        conditionalCopy.condition = expressions.pop();
+        if(node.hasElseBlock()) {
+            conditionalCopy.elseBlock = blocks.pop();
+            conditionalCopy.ifBlock = blocks.pop();
+        } else {
+            conditionalCopy.ifBlock = blocks.pop();
+        }
+        blocks.peek().statements.add(conditionalCopy);
+    }
+
+    @Override
+    public void preVisit(ASTContinue node) {
+        ASTContinue continueCopy = new ASTContinue();
+        continueCopy.lineNumber = node.lineNumber;
+        statements.push(continueCopy);
+    }
+
+    @Override
+    public void postVisit(ASTContinue node) {
+        blocks.peek().statements.add(statements.pop());
+    }
+
+    @Override
+    public void preVisit(ASTForLoop node) {
+        ASTForLoop forCopy = new ASTForLoop(null, null, null, null);
+        forCopy.lineNumber = node.lineNumber;
+        statements.push(forCopy);
+    }
+
+    public void postVisit(ASTForLoop node) {
+        ASTForLoop forCopy = (ASTForLoop)statements.pop();
+        forCopy.block = blocks.pop();
+        forCopy.upperBound = expressions.pop();
+        if(node.lowerBound != null) {
+            forCopy.lowerBound = expressions.pop();
+        }
+        forCopy.var = (ASTVariable)expressions.pop();
+        blocks.peek().statements.add(forCopy);
+    }
+
+    @Override
+    public void preVisit(ASTReturn node) {
+        ASTReturn returnCopy = new ASTReturn();
+        returnCopy.lineNumber = node.lineNumber;
+        statements.push(returnCopy);
+    }
+
+    @Override
+    public void postVisit(ASTReturn node) {
+        ASTReturn returnCopy = (ASTReturn)statements.pop();
+        if(node.hasValue()) {
+            returnCopy.value = expressions.pop();
+        }
+        blocks.peek().statements.add(returnCopy);
+    }
+
+    @Override
+    public void preVisit(ASTVoidAssignment node) {
+        ASTVoidAssignment assignmentCopy = new ASTVoidAssignment(null);
+        assignmentCopy.lineNumber = node.lineNumber;
+        statements.push(assignmentCopy);
+    }
+
+    @Override
+    public void postVisit(ASTVoidAssignment node) {
+        ASTVoidAssignment assignmentCopy = (ASTVoidAssignment)statements.pop();
+        assignmentCopy.assignment = (ASTAssignment)expressions.pop();
+        blocks.peek().statements.add(assignmentCopy);
+    }
+
+    @Override
+    public void preVisit(ASTVoidFunctionCall node) {
+        ASTVoidFunctionCall functionCallCopy = new ASTVoidFunctionCall(null);
+        functionCallCopy.lineNumber = node.lineNumber;
+        statements.push(functionCallCopy);
+    }
+
+    @Override
+    public void postVisit(ASTVoidFunctionCall node) {
+        ASTVoidFunctionCall functionCallCopy = (ASTVoidFunctionCall)statements.pop();
+        functionCallCopy.functionCall = (ASTFunctionCall)expressions.pop();
+        blocks.peek().statements.add(functionCallCopy);
+    }
+
+    @Override
+    public void preVisit(ASTVoidMethodCall node) {
+        ASTVoidMethodCall methodCallCopy = new ASTVoidMethodCall(null);
+        methodCallCopy.lineNumber = node.lineNumber;
+        statements.push(methodCallCopy);
+    }
+
+    @Override
+    public void postVisit(ASTVoidMethodCall node) {
+        ASTVoidMethodCall methodCallCopy = (ASTVoidMethodCall)statements.pop();
+        methodCallCopy.methodCall = (ASTMethodCall)expressions.pop();
+        blocks.peek().statements.add(methodCallCopy);
+    }
+
+    @Override
+    public void preVisit(ASTWhileLoop node) {
+        ASTWhileLoop whileCopy = new ASTWhileLoop(null, null);
+        whileCopy.lineNumber = node.lineNumber;
+        statements.push(whileCopy);
+    }
+
+    @Override
+    public void postVisit(ASTWhileLoop node) {
+        ASTWhileLoop whileCopy = (ASTWhileLoop)statements.pop();
+        whileCopy.guard = expressions.pop();
+        whileCopy.body = blocks.pop();
+        blocks.peek().statements.add(whileCopy);
+    }
+
+    @Override
+    public void postVisit(ASTSet node) {
+        ASTArgList argListCopy = (ASTArgList)expressions.pop();
+        ASTSet setCopy = new ASTSet(argListCopy);
+        setCopy.lineNumber = node.lineNumber;
+        expressions.push(setCopy);
+    }
+
+    @Override
+    public void postVisit(ASTMap node) {
+        ASTArgList argListCopy = (ASTArgList)expressions.pop();
+        ASTMap mapCopy = new ASTMap(argListCopy);
+        mapCopy.lineNumber = node.lineNumber;
+        expressions.push(mapCopy);
+    }
+
+    @Override
+    public void postVisit(ASTList node) {
+        ASTArgList argListCopy = (ASTArgList)expressions.pop();
+        ASTList listCopy = new ASTList(argListCopy);
+        listCopy.lineNumber = node.lineNumber;
+        expressions.push(listCopy);
+    }
+
+    @Override
+    public void postVisit(ASTLocation node) {
+        ASTLocation locationCopy = new ASTLocation(node.name);
+        locationCopy.lineNumber = node.lineNumber;
+        expressions.push(locationCopy);
+    }
+
+    @Override
+    public void postVisit(ASTBinaryExpr node) {
+        ASTExpression rightChild = expressions.pop();
+        ASTExpression leftChild = expressions.pop();
+        ASTBinaryExpr binExCopy = new ASTBinaryExpr(node.operator, leftChild, rightChild);
+        binExCopy.lineNumber = node.lineNumber;
+        expressions.push(binExCopy);
+    }
+
+    @Override
+    public void postVisit(ASTAssignment node) {
+        ASTExpression valueCopy = expressions.pop();
+        ASTAssignment assignmentCopy;
+        if(expressions.peek() instanceof ASTMemberAccess) {
+            ASTMemberAccess memberCopy = (ASTMemberAccess)expressions.pop();
+            assignmentCopy = new ASTAssignment(node.op, memberCopy, valueCopy);
+        } else {
+            ASTVariable varCopy = (ASTVariable)expressions.pop();
+            assignmentCopy = new ASTAssignment(node.op, varCopy, valueCopy);
+        }
+        assignmentCopy.lineNumber = node.lineNumber;
+        expressions.push(assignmentCopy);
+    }
+
+    @Override
+    public void postVisit(ASTMethodCall node) {
+        ASTFunctionCall functionCallCopy = (ASTFunctionCall)expressions.pop();
+        ASTExpression invokerCopy = expressions.pop();
+        ASTMethodCall methodCallCopy = new ASTMethodCall(invokerCopy, functionCallCopy);
+        methodCallCopy.lineNumber = node.lineNumber;
+        expressions.push(methodCallCopy);
+    }
+
+    @Override
+    public void postVisit(ASTMemberAccess node) {
+        ASTVariable varCopy = (ASTVariable)expressions.pop();
+        ASTVariable instanceCopy = (ASTVariable) expressions.pop();
+        ASTMemberAccess memberAccessCopy = new ASTMemberAccess(instanceCopy.name, varCopy);
+        memberAccessCopy.lineNumber = node.lineNumber;
+        expressions.push(memberAccessCopy);
+    }
+
+    @Override
+    public void postVisit(ASTEntry node) {
+        ASTExpression valueCopy = expressions.pop();
+        ASTExpression keyCopy = expressions.pop();
+        ASTEntry entryCopy = new ASTEntry(keyCopy, valueCopy);
+        entryCopy.lineNumber = node.lineNumber;
+        expressions.push(entryCopy);
+    }
+
+    @Override
+    public void postVisit(ASTArgList node) {
+        Deque<ASTExpression> argsStack = new ArrayDeque<>();
+        for(int i = 0; i < node.arguments.size(); i++) {
+            argsStack.push(expressions.pop());
+        }
+        List<ASTExpression> argsCopy = new ArrayList<>();
+        while(!argsStack.isEmpty()) {
+            argsCopy.add(argsStack.pop());
+        }
+        ASTArgList argListCopy = new ASTArgList(argsCopy);
+        argListCopy.lineNumber = node.lineNumber;
+        expressions.push(argListCopy);
+    }
+
+    @Override
+    public void postVisit(ASTFunctionCall node) {
+        ASTFunctionCall functionCallCopy = new ASTFunctionCall(node.name);
+        functionCallCopy.lineNumber = node.lineNumber;
+        Deque<ASTExpression> argsStack = new ArrayDeque<>();
+        for(int i = 0; i < node.arguments.size(); i++) {
+            argsStack.push(expressions.pop());
+        }
+        while(!argsStack.isEmpty()) {
+            functionCallCopy.arguments.add(argsStack.pop());
+        }
+        expressions.push(functionCallCopy);
+    }
+
+    @Override
+    public void postVisit(ASTLiteral node) {
+        ASTLiteral literalCopy = new ASTLiteral(((HMTypeBase)node.type).getBaseType(), node.value);
+        literalCopy.lineNumber = node.lineNumber;
+        expressions.push(literalCopy);
+    }
+
+    @Override
+    public void postVisit(ASTUnaryExpr node) {
+        ASTUnaryExpr unaryExprCopy = new ASTUnaryExpr(node.operator, expressions.pop());
+        unaryExprCopy.lineNumber = node.lineNumber;
+        expressions.push(unaryExprCopy);
+    }
+
+    @Override
+    public void postVisit(ASTVariable node) {
+        ASTVariable varCopy;
+        if(node.isCollection) {
+            varCopy = new ASTVariable(node.name, expressions.pop());
+        } else {
+            varCopy = new ASTVariable(node.name);
+        }
+        varCopy.lineNumber = node.lineNumber;
+        expressions.push(varCopy);
+    }
+
+    @Override
+    public void preVisit(ASTBlock node) {
+        ASTBlock blockCopy = new ASTBlock();
+        blockCopy.lineNumber = node.lineNumber;
+        blocks.push(blockCopy);
+    }
+}

--- a/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
@@ -2,6 +2,8 @@ package com.github.lessjava.visitor.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.github.lessjava.types.ast.ASTAbstractFunction;
 import com.github.lessjava.types.ast.ASTAbstractFunction.Parameter;
@@ -47,7 +49,10 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
             return;
         }
 
-        ASTAbstractFunction prototype = program.functions.stream()
+        ArrayList<ASTAbstractFunction> functions = new ArrayList<>(program.functions);
+        program.classes.forEach(c -> functions.addAll(c.block.methods.stream().filter(m -> m.isConstructor).collect(Collectors.toList())));
+
+        ASTAbstractFunction prototype = functions.stream()
             .filter(f -> f.name.equals(node.name) && f.parameters.size() == node.arguments.size())
             .findAny()
             .orElse(null);

--- a/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
@@ -49,6 +49,10 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
             return;
         }
 
+        if(node.name.equals(("super"))) {
+            return;
+        }
+
         ArrayList<ASTAbstractFunction> functions = new ArrayList<>(program.functions);
         program.classes.forEach(c -> functions.addAll(c.block.methods.stream().filter(m -> m.isConstructor).collect(Collectors.toList())));
 
@@ -62,7 +66,8 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
             return;
         }
 
-        if (prototype != null && prototype.concrete) {
+        // Don't instantiate if there's either already a concrete implementation or if the prototype is a constructor (ASTMethod)
+        if (prototype.concrete || prototype instanceof ASTMethod) {
             return;
         }
 
@@ -85,9 +90,8 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
             return null;
         }
 
-        ASTBlock blockCopy = new ASTBlock();
-        blockCopy.statements = prototype.body.statements;
-        blockCopy.variables = prototype.body.variables;
+        LJDuplicateBlock blockDuplicator = new LJDuplicateBlock();
+        ASTBlock blockCopy = blockDuplicator.duplicateBlock(prototype.body);
 
         ASTFunction functionInstance = new ASTFunction(prototype.name, prototype.returnType, blockCopy);
 
@@ -95,6 +99,7 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
 
         functionInstance.concrete = true;
         functionInstance.parameters = new ArrayList<>();
+        functionInstance.lineNumber = prototype.lineNumber;
 
         for (int i = 0; i < arguments.size(); i++) {
             String pname = prototype.parameters.get(i).name;
@@ -146,9 +151,8 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
 
         ASTClass containingClass = ASTClass.nameClassMap.get(prototype.containingClassName);
 
-        ASTBlock blockCopy = new ASTBlock();
-        blockCopy.statements = prototype.body.statements;
-        blockCopy.variables = prototype.body.variables;
+        LJDuplicateBlock blockDuplicator = new LJDuplicateBlock();
+        ASTBlock blockCopy = blockDuplicator.duplicateBlock(prototype.body);
 
         ASTFunction functionInstance = new ASTFunction(prototype.name, prototype.returnType, blockCopy);
 
@@ -156,6 +160,7 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
 
         functionInstance.concrete = true;
         functionInstance.parameters = new ArrayList<>();
+        functionInstance.lineNumber = prototype.lineNumber;
 
         for (int i = 0; i < arguments.size(); i++) {
             String pname = prototype.parameters.get(i).name;

--- a/src/main/java/com/github/lessjava/visitor/impl/LJStaticAnalysis.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJStaticAnalysis.java
@@ -62,6 +62,12 @@ public class LJStaticAnalysis extends StaticAnalysis {
     @Override
     public void postVisit(ASTVariable node) {
         super.postVisit(node);
+
+        // Don't need to check if the var is within a member access
+        if(node.getParent() instanceof ASTMemberAccess) {
+            return;
+        }
+
         List<Symbol> symbols = BuildSymbolTables.searchScopesForSymbol(node, node.name, Symbol.SymbolType.VARIABLE);
 
         if(symbols == null || symbols.isEmpty()) {

--- a/src/main/java/com/github/lessjava/visitor/impl/StaticAnalysis.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/StaticAnalysis.java
@@ -16,6 +16,7 @@ import com.github.lessjava.visitor.LJDefaultASTVisitor;
  */
 public class StaticAnalysis extends LJDefaultASTVisitor {
     protected static List<String> errors = new ArrayList<String>();
+    public static boolean collectErrors = true;
 
     /**
      * Report an {@link InvalidProgramException} error. This error is saved for
@@ -34,7 +35,9 @@ public class StaticAnalysis extends LJDefaultASTVisitor {
      * @param msg
      */
     public static void addError(ASTNode node, String msg) {
-        errors.add("Line " + node.lineNumber + ": " + msg);
+        if(collectErrors) {
+            errors.add("Line " + node.lineNumber + ": " + msg);
+        }
     }
 
     /**

--- a/src/test/java/com/github/lessjava/visitor/impl/LJDuplicateBlockTest.java
+++ b/src/test/java/com/github/lessjava/visitor/impl/LJDuplicateBlockTest.java
@@ -1,0 +1,105 @@
+package com.github.lessjava.visitor.impl;
+
+import com.github.lessjava.types.ast.ASTAssignment;
+import com.github.lessjava.types.ast.ASTBinaryExpr;
+import com.github.lessjava.types.ast.ASTBlock;
+import com.github.lessjava.types.ast.ASTConditional;
+import com.github.lessjava.types.ast.ASTContinue;
+import com.github.lessjava.types.ast.ASTForLoop;
+import com.github.lessjava.types.ast.ASTFunctionCall;
+import com.github.lessjava.types.ast.ASTLiteral;
+import com.github.lessjava.types.ast.ASTVariable;
+import com.github.lessjava.types.ast.ASTVoidAssignment;
+import com.github.lessjava.types.ast.ASTVoidFunctionCall;
+import com.github.lessjava.types.inference.HMType;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LJDuplicateBlockTest {
+
+    LJDuplicateBlock underTest;
+
+    @BeforeEach
+    public void init() {
+        underTest = new LJDuplicateBlock();
+    }
+
+    @Test
+    public void testTypesIndependent() {
+        ASTBlock original = new ASTBlock();
+
+        // var = 0
+        original.statements.add(new ASTVoidAssignment(new ASTAssignment(ASTBinaryExpr.BinOp.ASGN, new ASTVariable("var"), new ASTLiteral(HMType.BaseDataType.INT, 0))));
+
+        ASTBlock copy = underTest.duplicateBlock(original);
+
+        assertEquals(1, copy.statements.size());
+        assertEquals("var", ((ASTVoidAssignment)copy.statements.get(0)).assignment.variable.name);
+        HMType originalType = ((ASTVoidAssignment)original.statements.get(0)).assignment.type;
+        HMType copyType = ((ASTVoidAssignment)copy.statements.get(0)).assignment.type;
+        assertNotSame(originalType, copyType);
+    }
+
+    @Test
+    public void testComplexBlock() {
+        // Tests that the following block can be duplicated
+        /*
+        var = 5
+        for(i: var-2 -> var+2) {
+          if(i == 5) {
+            continue
+          } else {
+            println("Not 5")
+          }
+          println(i)
+        }
+         */
+
+        ASTBlock original = new ASTBlock();
+
+        // var = 5
+        original.statements.add(new ASTVoidAssignment(new ASTAssignment(ASTBinaryExpr.BinOp.ASGN, new ASTVariable("var"), new ASTLiteral(HMType.BaseDataType.INT, 5))));
+
+        // var - 2
+        ASTBinaryExpr lower = new ASTBinaryExpr(ASTBinaryExpr.BinOp.SUB, new ASTVariable("var"), new ASTLiteral(HMType.BaseDataType.INT, 2));
+
+        // var+2
+        ASTBinaryExpr upper = new ASTBinaryExpr(ASTBinaryExpr.BinOp.ADD, new ASTVariable("var"), new ASTLiteral(HMType.BaseDataType.INT, 2));
+
+        // for(i: var-2 -> var+2) {...
+        ASTForLoop forLoop = new ASTForLoop(new ASTVariable("i"), lower, upper, new ASTBlock());
+        original.statements.add(forLoop);
+
+        // if(i == 5) {...
+        ASTConditional cond = new ASTConditional(new ASTBinaryExpr(ASTBinaryExpr.BinOp.EQ, new ASTVariable("i"), new ASTLiteral(HMType.BaseDataType.INT, 5)), new ASTBlock(), new ASTBlock());
+        forLoop.block.statements.add(cond);
+
+        // continue
+        cond.ifBlock.statements.add(new ASTContinue());
+
+        // ...} else {...
+        // println("Not 5")
+        ASTVoidFunctionCall funcCall = new ASTVoidFunctionCall(new ASTFunctionCall("println"));
+        cond.elseBlock.statements.add(funcCall);
+        funcCall.functionCall.arguments.add(new ASTLiteral(HMType.BaseDataType.STR, "Not 5"));
+
+        // }
+        // println(i)
+        ASTVoidFunctionCall printI = new ASTVoidFunctionCall(new ASTFunctionCall("println"));
+        forLoop.block.statements.add(printI);
+        printI.functionCall.arguments.add(new ASTVariable("i"));
+
+        ASTBlock copy = underTest.duplicateBlock(original);
+
+        assertEquals(original.statements.size(), copy.statements.size());
+        ASTForLoop copyFor = (ASTForLoop)copy.statements.get(1);
+        ASTConditional copyConditional = (ASTConditional)copyFor.block.statements.get(0);
+        ASTVoidFunctionCall copyPrintI = (ASTVoidFunctionCall)copyFor.block.statements.get(1);
+        assertEquals(forLoop.block.statements.size(), copyFor.block.statements.size());
+        assertEquals(cond.ifBlock.statements.size(), copyConditional.ifBlock.statements.size());
+        assertEquals(cond.elseBlock.statements.size(), copyConditional.elseBlock.statements.size());
+        assertEquals(printI.functionCall.arguments.size(), copyPrintI.functionCall.arguments.size());
+    }
+
+}

--- a/src/test/java/com/github/lessjava/visitor/impl/LJStaticAnalysisTest.java
+++ b/src/test/java/com/github/lessjava/visitor/impl/LJStaticAnalysisTest.java
@@ -2,6 +2,8 @@ package com.github.lessjava.visitor.impl;
 
 import com.github.lessjava.generated.LJLexer;
 import com.github.lessjava.generated.LJParser;
+import com.github.lessjava.types.ast.ASTClass;
+import com.github.lessjava.types.ast.ASTClassBlock;
 import com.github.lessjava.types.ast.ASTProgram;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -43,6 +45,9 @@ class LJStaticAnalysisTest {
         this.underTest = new LJStaticAnalysis();
         StaticAnalysis.resetErrors();
         BuildSymbolTables.nodeSymbolTableMap.clear();
+        ASTClass.nameClassMap.clear();
+        ASTClassBlock.nameAttributeMap.clear();
+        StaticAnalysis.collectErrors = true;
     }
 
     private ASTProgram compile(String programText) {
@@ -74,6 +79,7 @@ class LJStaticAnalysisTest {
         program.traverse(inferConstructors);
 
         do {
+            program.traverse(buildParentLinks); // Rebuild parent links in case we instantiated new functions
             StaticAnalysis.resetErrors();   // Remove errors found in old iterations
             program.traverse(buildSymbolTables);
             program.traverse(instantiateFunctions);


### PR DESCRIPTION
Admittedly this should've been split into two PRs, but here's the gist of what's new

- Member accesses are now represented by two ASTVariables, instance and var, instead of having className and referencedClassName
- Member accesses work
- HMTypeClass can now be unified based on inheritance
- Fixed a bug where two instances of the same function had the same block, which both made the AST no longer a tree and made it so that types had to be identical across all instances of functions