### PR TITLE
Fix constructors with multiple blocks bug

### DIFF
--- a/src/main/java/com/github/lessjava/types/ast/ASTClass.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTClass.java
@@ -114,12 +114,13 @@ public class ASTClass extends ASTNode {
         }
     }
 
-    public boolean hasExplicitConstructor() {
-        List<String> methodNames = this.block.methods.stream()
-                                                     .map(m -> m.name)
-                                                     .collect(Collectors.toList());
-
-        return methodNames.contains(signature.className);
+    /**
+     * Return true iff the class has a constructor that takes no parameters.
+     *
+     * @return true iff the class has a constructor that takes no parameters
+     */
+    public boolean hasEmptyConstructor() {
+        return block.constructors.stream().map(c -> c.parameters).anyMatch(List::isEmpty);
     }
 
     public boolean hasMethod(String name) {

--- a/src/main/java/com/github/lessjava/types/ast/ASTClassBlock.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTClassBlock.java
@@ -10,7 +10,7 @@ public class ASTClassBlock extends ASTNode {
 
     public Set<ASTAttribute> classAttributes;
     public Set<ASTMethod> methods;
-    public ASTMethod constructor;
+    public Set<ASTMethod> constructors;
 
     public ASTClassBlock() {
         this(null, null, null);
@@ -23,7 +23,10 @@ public class ASTClassBlock extends ASTNode {
     public ASTClassBlock(Set<ASTAttribute> attributes, Set<ASTMethod> methods, ASTMethod constructor) {
         this.classAttributes = attributes != null ? attributes : new HashSet<>();
         this.methods = methods != null ? methods : new HashSet<>();
-        this.constructor = constructor;
+        this.constructors = new HashSet<>();
+        if(constructor != null) {
+            this.constructors.add(constructor);
+        }
 
         for (ASTAttribute a: classAttributes) {
             nameAttributeMap.put(a.assignment.variable.name, a);

--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTConverter.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTConverter.java
@@ -188,12 +188,8 @@ public class LJASTConverter extends LJBaseListener {
         ASTMethod method;
         String scope;
 
-        boolean isConstructor = false;
-
-        // Null if constructor
         if (ctx.scope == null) {
             scope = ASTClass.PUBLIC;
-            isConstructor = true;
         } else {
             scope = ctx.scope.getText();
         }
@@ -202,13 +198,13 @@ public class LJASTConverter extends LJBaseListener {
 
         method = new ASTMethod(scope, function, this.currentClassSignature.className);
         method.lineNumber = ctx.getStart().getLine();
-        method.isConstructor = isConstructor;
+        method.isConstructor = function.name.equals(this.currentClassSignature.className);
         method.containingClassName = currentClassSignature.className;
 
         currentClassBlock.methods.add(method);
 
-        if (isConstructor) {
-            currentClassBlock.constructor = method;
+        if (method.isConstructor) {
+            currentClassBlock.constructors.add(method);
         }
 
         method.setDepth(ctx.depth());

--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTInferConstructors.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTInferConstructors.java
@@ -1,5 +1,8 @@
 package com.github.lessjava.visitor.impl;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import com.github.lessjava.types.ast.ASTAbstractFunction.Parameter;
 import com.github.lessjava.types.ast.ASTBlock;
 import com.github.lessjava.types.ast.ASTClass;
@@ -12,6 +15,15 @@ import com.github.lessjava.types.inference.impl.HMTypeClass;
 import com.github.lessjava.visitor.LJDefaultASTVisitor;
 
 public class LJASTInferConstructors extends LJDefaultASTVisitor {
+
+    /**
+     * Add constructors to a class. After running, every class will:
+     * - Have an empty constructor
+     * - Have constructors that make calls to any superconstructors that exist in a parent class, unless they've been
+     *   overridden in the subclass
+     *
+     * @param node The class to generate constructors for
+     */
     @Override
     public void postVisit(ASTClass node) {
         super.postVisit(node);
@@ -20,49 +32,63 @@ public class LJASTInferConstructors extends LJDefaultASTVisitor {
             return;
         }
 
-        if (!node.hasExplicitConstructor()) {
-            ASTMethod constructor = generateConstructor(node);
+        if (!node.hasEmptyConstructor()) {
             ASTMethod emptyConstructor = generateEmptyConstructor(node);
+            node.block.methods.add(emptyConstructor);
+            node.block.constructors.add(emptyConstructor);
+        }
 
+        for(ASTMethod constructor : generateParentConstructors(node)) {
             node.block.methods.add(constructor);
-            node.block.methods.add(emptyConstructor);
-            node.block.constructor = constructor;
-        } else {
-            ASTMethod emptyConstructor = generateEmptyConstructor(node);
-            node.block.methods.add(emptyConstructor);
+            node.block.constructors.add(constructor);
         }
     }
 
-    private ASTMethod generateConstructor(ASTClass node) {
-        String name = node.signature.className;
-        HMTypeClass type = new HMTypeClass(name);
-        ASTFunction f = new ASTFunction(name, type, new ASTBlock());
-        ASTMethod constructor = new ASTMethod(ASTClass.PUBLIC, f, name);
+    /**
+     * Generate constructors for every constructor in a class's superclass, if it has one. If the current class already
+     * has a constructor with the same number of parameters in a constructor in the superclass, do not generate a new
+     * constructor.
+     *
+     * @param node The class to generate constructors for
+     * @return A set of constructors that make calls to a superconstructor
+     */
+    private Set<ASTMethod> generateParentConstructors(ASTClass node) {
+        Set<ASTMethod> constructors = new HashSet<>();
+        if(node.parent != null) {
+            for(ASTMethod parentConstructor : node.parent.block.constructors) {
+                // Only bring the superconstructor into the subclass if the subclass doesn't have a constructor with a matching # of parameters
+                if(node.block.constructors.stream().noneMatch(c -> c.parameters.size() == parentConstructor.parameters.size())) {
+                    String name = node.signature.className;
+                    HMTypeClass type = new HMTypeClass(name);
+                    ASTFunction f = new ASTFunction(name, type, new ASTBlock());
+                    ASTMethod constructor = new ASTMethod(ASTClass.PUBLIC, f, name);
+                    ASTFunctionCall superConstructor = new ASTFunctionCall("super");
 
-        if (node.parent != null) {
-            ASTFunctionCall superConstructor = new ASTFunctionCall("super");
-
-            for (Parameter p: node.parent.block.constructor.function.parameters) {
-                f.parameters.add(p);
-                ASTVariable v = new ASTVariable(p.name);
-                superConstructor.arguments.add(v);
-
-                v.setParent(f);
+                    // Copy all parameters from the superconstructor to the constructor and the call to super
+                    for(Parameter p : parentConstructor.parameters) {
+                        f.parameters.add(p);
+                        ASTVariable v = new ASTVariable(p.name);
+                        superConstructor.arguments.add(v);
+                        v.setParent(f);
+                    }
+                    f.body.statements.add(new ASTVoidFunctionCall(superConstructor));
+                    f.setParent(constructor);
+                    constructor.setParent(node.block);
+                    constructor.isConstructor = true;
+                    constructor.lineNumber = parentConstructor.lineNumber;
+                    constructors.add(constructor);
+                }
             }
-
-            f.body = new ASTBlock();
-
-            superConstructor.setParent(f);
-            f.body.statements.add(new ASTVoidFunctionCall(superConstructor));
         }
-
-        f.setParent(constructor);
-        constructor.setParent(node.block);
-        constructor.isConstructor = true;
-
-        return constructor;
+        return constructors;
     }
 
+    /**
+     * Generate a constructor taking no parameters, calling the empty superconstructor if the class is a subclass
+     *
+     * @param node The class to make a constructor for
+     * @return A constructor taking no parameters
+     */
     private ASTMethod generateEmptyConstructor(ASTClass node) {
         String name = node.signature.className;
         HMTypeClass type = new HMTypeClass(name);

--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTInferTypes.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTInferTypes.java
@@ -8,6 +8,7 @@ import com.github.lessjava.types.ast.ASTAbstractFunction;
 import com.github.lessjava.types.ast.ASTAbstractFunction.Parameter;
 import com.github.lessjava.types.ast.ASTArgList;
 import com.github.lessjava.types.ast.ASTAssignment;
+import com.github.lessjava.types.ast.ASTAttribute;
 import com.github.lessjava.types.ast.ASTBinaryExpr;
 import com.github.lessjava.types.ast.ASTClass;
 import com.github.lessjava.types.ast.ASTClassBlock;
@@ -27,6 +28,7 @@ import com.github.lessjava.types.ast.ASTReturn;
 import com.github.lessjava.types.ast.ASTSet;
 import com.github.lessjava.types.ast.ASTUnaryExpr;
 import com.github.lessjava.types.ast.ASTVariable;
+import com.github.lessjava.types.ast.ASTVoidAssignment;
 import com.github.lessjava.types.inference.HMType;
 import com.github.lessjava.types.inference.HMType.BaseDataType;
 import com.github.lessjava.types.inference.impl.HMTypeBase;
@@ -64,7 +66,12 @@ public class LJASTInferTypes extends LJAbstractAssignTypes {
             node.concrete = node.function.concrete = true;
 
             for (Parameter p : node.function.parameters) {
-                p.type = unify(node, p.type, ASTClassBlock.nameAttributeMap.get(p.name).assignment.type);
+                ASTAttribute member = ASTClassBlock.nameAttributeMap.get(p.name);
+                if (member == null) {
+                    StaticAnalysis.addError(node, "Constructor parameter names must match class member names. \"" + p.name + "\" is not a member.");
+                } else {
+                    p.type = unify(node, p.type, ASTClassBlock.nameAttributeMap.get(p.name).assignment.type);
+                }
             }
         } else {
             node.returnType = node.function.returnType;

--- a/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
@@ -54,7 +54,7 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
         }
 
         ArrayList<ASTAbstractFunction> functions = new ArrayList<>(program.functions);
-        program.classes.forEach(c -> functions.addAll(c.block.methods.stream().filter(m -> m.isConstructor).collect(Collectors.toList())));
+        program.classes.forEach(c -> functions.addAll(c.block.constructors));
 
         ASTAbstractFunction prototype = functions.stream()
             .filter(f -> f.name.equals(node.name) && f.parameters.size() == node.arguments.size())

--- a/src/test/java/com/github/lessjava/visitor/impl/LJASTInferConstructorsTest.java
+++ b/src/test/java/com/github/lessjava/visitor/impl/LJASTInferConstructorsTest.java
@@ -1,0 +1,114 @@
+package com.github.lessjava.visitor.impl;
+
+import java.util.Optional;
+
+import com.github.lessjava.generated.LJLexer;
+import com.github.lessjava.generated.LJParser;
+import com.github.lessjava.types.ast.ASTBinaryExpr;
+import com.github.lessjava.types.ast.ASTClass;
+import com.github.lessjava.types.ast.ASTFunctionCall;
+import com.github.lessjava.types.ast.ASTMethod;
+import com.github.lessjava.types.ast.ASTProgram;
+import com.github.lessjava.types.ast.ASTVariable;
+import com.github.lessjava.types.ast.ASTVoidFunctionCall;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+class LJASTInferConstructorsTest {
+
+    private ASTProgram compile(String programText) {
+        LJLexer lexer = new LJLexer(new ANTLRInputStream(programText));
+        ParseTreeWalker walker = new ParseTreeWalker();
+
+        LJParser parser = new LJParser(new CommonTokenStream(lexer));
+        LJASTConverter converter = new LJASTConverter();
+
+        BuildParentLinks buildParentLinks = new BuildParentLinks();
+        LJASTBuildClassLinks buildClassLinks = new LJASTBuildClassLinks();
+        BuildSymbolTables buildSymbolTables = new BuildSymbolTables();
+        LJASTInferTypes inferTypes = new LJASTInferTypes();
+        // PrintDebugTree printTree = new PrintDebugTree();
+        LJASTCheckTypesHaveChanged checkTypesHaveChanged = new LJASTCheckTypesHaveChanged();
+        LJInstantiateFunctions instantiateFunctions = new LJInstantiateFunctions();
+        LJASTInferConstructors inferConstructors = new LJASTInferConstructors();
+
+        // ANTLR Parsing
+        ParseTree parseTree = parser.program();
+
+        // Convert to AST
+        walker.walk(converter, parseTree);
+        ASTProgram program = converter.getAST();
+
+        // Apply visitors to AST
+        program.traverse(buildParentLinks);
+        program.traverse(buildClassLinks);
+        program.traverse(inferConstructors);
+
+        return program;
+    }
+
+    @Test
+    public void testEmptyConstructorGenerated() {
+        String programText =
+                "A {\n" +
+                "}";
+        compile(programText);
+        ASTClass a = ASTClass.nameClassMap.get("A");
+        assertEquals(1, a.block.constructors.size());
+        assertTrue(a.block.constructors.stream().anyMatch(constructor -> constructor.parameters.isEmpty()));
+    }
+
+    @Test
+    public void testSuperConstructors() {
+        String programText =
+                "A {\n" +
+                        "public num = 0\n" +
+                        "A(num) {\n" +
+                            "this.num = num\n" +
+                        "}" +
+                "}\n" +
+                "B extends A {\n" +
+                "}";
+        compile(programText);
+        ASTClass b = ASTClass.nameClassMap.get("B");
+        assertEquals(2, b.block.constructors.size());
+        Optional<ASTMethod> optionalConstructor = b.block.constructors.stream().filter(constructor -> constructor.parameters.size() == 1).findFirst();
+        assertTrue(optionalConstructor.isPresent());
+        ASTMethod constructor = optionalConstructor.get();
+        ASTFunctionCall callToSuper = ((ASTVoidFunctionCall)constructor.function.body.statements.get(0)).functionCall;
+        assertEquals("super", callToSuper.name);
+        assertEquals(1, callToSuper.arguments.size());
+        assertEquals("num", ((ASTVariable)callToSuper.arguments.get(0)).name);
+    }
+
+    @Test
+    public void testConstructorsNotReplaced() {
+        String programText =
+                "A {\n" +
+                        "public num = 0\n" +
+                        "A(num) {\n" +
+                            "this.num = num\n" +
+                        "}" +
+                "}\n" +
+                "B extends A {\n" +
+                        "B(num) {\n" +
+                            "super(num+1)\n" +
+                        "}" +
+                "}";
+        ASTProgram program = compile(programText);
+        ASTClass b = ASTClass.nameClassMap.get("B");
+        assertEquals(2, b.block.constructors.size());
+        Optional<ASTMethod> optionalConstructor = b.block.constructors.stream().filter(constructor -> constructor.parameters.size() == 1).findFirst();
+        assertTrue(optionalConstructor.isPresent());
+        ASTMethod constructor = optionalConstructor.get();
+        ASTFunctionCall callToSuper = ((ASTVoidFunctionCall)constructor.function.body.statements.get(0)).functionCall;
+        assertEquals("super", callToSuper.name);
+        assertEquals(1, callToSuper.arguments.size());
+        assertTrue(callToSuper.arguments.get(0) instanceof ASTBinaryExpr);
+    }
+
+}


### PR DESCRIPTION
Before this, constructors in subclasses could end up having multiple blocks due to a bug in constructor generation. This is fixed here, as well as determining whether a method is a constructor based on the name rather than the scope and making parameter type inference safer in constructors.