### PR TITLE
Enable passing tests + low-hanging fruit

### DIFF
--- a/src/main/java/com/github/lessjava/LJCompiler.java
+++ b/src/main/java/com/github/lessjava/LJCompiler.java
@@ -93,6 +93,10 @@ public class LJCompiler {
         // Apply visitors to AST
         program.traverse(buildParentLinks);
         program.traverse(buildClassLinks);
+        if(!StaticAnalysis.getErrors().isEmpty()) {
+            System.out.printf("%n%s%n", StaticAnalysis.getErrorString());
+            System.exit(1);
+        }
         program.traverse(inferConstructors);
 
         do {

--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTBuildClassLinks.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTBuildClassLinks.java
@@ -10,11 +10,37 @@ public class LJASTBuildClassLinks extends LJDefaultASTVisitor {
 
     public final static Map<String, ASTClass> nameClassMap = new HashMap<>();
 
+    // Add some undeclarable classes to the map
+    static {
+        nameClassMap.put("Object",null);
+        nameClassMap.put("String", null);
+        nameClassMap.put("Integer", null);
+        nameClassMap.put("Double", null);
+        nameClassMap.put("Boolean", null);
+        nameClassMap.put("Char", null);
+        nameClassMap.put("LJList", null);
+        nameClassMap.put("LJSet", null);
+        nameClassMap.put("LJMap", null);
+    }
+
     @Override
     public void postVisit(ASTClass node) {
         super.postVisit(node);
 
-        nameClassMap.putIfAbsent(node.signature.className, node);
-        node.parent = nameClassMap.get(node.signature.superName);
+        String className = node.signature.className;
+        if(nameClassMap.containsKey(className)) {
+            StaticAnalysis.addError(node, className + " already declared.");
+        } else {
+            nameClassMap.put(className, node);
+        }
+
+        String superName = node.signature.superName;
+        if(superName != null) {
+            if(nameClassMap.containsKey(superName)) {
+                node.parent = nameClassMap.get(superName);
+            } else {
+                StaticAnalysis.addError(node, "Superclass " + superName + " not found.");
+            }
+        }
     }
 }

--- a/src/main/java/com/github/lessjava/visitor/impl/LJStaticAnalysis.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJStaticAnalysis.java
@@ -367,7 +367,12 @@ public class LJStaticAnalysis extends StaticAnalysis {
         super.postVisit(node);
         if(node.instance.type instanceof HMTypeClass) {
             ASTClass instanceClass = ASTClass.nameClassMap.get(((HMTypeClass)node.instance.type).name);
-            ASTAttribute member = instanceClass.block.classAttributes.stream().filter(attr -> attr.assignment.variable.name.equals(node.var.name)).findFirst().orElse(null);
+            ASTClass classToLookIn = instanceClass;
+            ASTAttribute member;
+            do {
+                member = classToLookIn.block.classAttributes.stream().filter(attr -> attr.assignment.variable.name.equals(node.var.name)).findFirst().orElse(null);
+                classToLookIn = classToLookIn.parent;
+            } while (member == null && classToLookIn != null);
             if (member == null) {
                 addError(node, node.instance.name + " does not have attribute " + node.var.name);
                 return;

--- a/src/test/java/com/github/lessjava/visitor/impl/LJASTInferConstructorsTest.java
+++ b/src/test/java/com/github/lessjava/visitor/impl/LJASTInferConstructorsTest.java
@@ -6,6 +6,7 @@ import com.github.lessjava.generated.LJLexer;
 import com.github.lessjava.generated.LJParser;
 import com.github.lessjava.types.ast.ASTBinaryExpr;
 import com.github.lessjava.types.ast.ASTClass;
+import com.github.lessjava.types.ast.ASTClassBlock;
 import com.github.lessjava.types.ast.ASTFunctionCall;
 import com.github.lessjava.types.ast.ASTMethod;
 import com.github.lessjava.types.ast.ASTProgram;
@@ -16,6 +17,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class LJASTInferConstructorsTest {
@@ -46,9 +48,28 @@ class LJASTInferConstructorsTest {
         // Apply visitors to AST
         program.traverse(buildParentLinks);
         program.traverse(buildClassLinks);
+        if(!StaticAnalysis.getErrors().isEmpty()) {
+            return program;
+        }
         program.traverse(inferConstructors);
 
         return program;
+    }
+
+    @BeforeEach
+    public void init() {
+        ASTClass.nameClassMap.clear();
+        ASTClassBlock.nameAttributeMap.clear();
+        LJASTBuildClassLinks.nameClassMap.clear();
+        LJASTBuildClassLinks.nameClassMap.put("Object",null);
+        LJASTBuildClassLinks.nameClassMap.put("String", null);
+        LJASTBuildClassLinks.nameClassMap.put("Integer", null);
+        LJASTBuildClassLinks.nameClassMap.put("Double", null);
+        LJASTBuildClassLinks.nameClassMap.put("Boolean", null);
+        LJASTBuildClassLinks.nameClassMap.put("Char", null);
+        LJASTBuildClassLinks.nameClassMap.put("LJList", null);
+        LJASTBuildClassLinks.nameClassMap.put("LJSet", null);
+        LJASTBuildClassLinks.nameClassMap.put("LJMap", null);
     }
 
     @Test


### PR DESCRIPTION
Many of the static analysis unit tests were disabled during development, this re-enables the passing ones. Also took care of some low-hanging fruit in building class links.