### PR TITLE
Clear static analysis errors between test runs

### DIFF
--- a/src/test/java/com/github/lessjava/visitor/impl/LJASTInferConstructorsTest.java
+++ b/src/test/java/com/github/lessjava/visitor/impl/LJASTInferConstructorsTest.java
@@ -71,6 +71,7 @@ class LJASTInferConstructorsTest {
         LJASTBuildClassLinks.nameClassMap.put("LJList", null);
         LJASTBuildClassLinks.nameClassMap.put("LJSet", null);
         LJASTBuildClassLinks.nameClassMap.put("LJMap", null);
+        StaticAnalysis.resetErrors();
     }
 
     @Test


### PR DESCRIPTION
From what I saw with @lam2mo after the meeting today, this should fix the build issues. I can't verify this though, since the tests were already passing on my machine anyway.