### PR TITLE
Fix increment/decrement operators (compound assignments)

### DIFF
--- a/src/main/java/com/github/lessjava/types/ast/ASTAssignment.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTAssignment.java
@@ -11,13 +11,15 @@ public class ASTAssignment extends ASTBinaryExpr {
     public ASTMemberAccess memberAccess;
 
     public ASTAssignment(BinOp op, ASTVariable variable, ASTExpression value) {
-        super(BinOp.ASGN, variable, value);
+        super(op, variable, value);
+        this.op = op;
         this.variable = (ASTVariable) super.leftChild;
         this.value = value;
     }
 
     public ASTAssignment(BinOp op, ASTMemberAccess memberAccess, ASTExpression value) {
-        this(BinOp.ASGN, memberAccess.var, value);
+        this(op, memberAccess.var, value);
+        this.op = op;
         this.memberAccess = memberAccess;
         this.value = value;
     }
@@ -37,9 +39,9 @@ public class ASTAssignment extends ASTBinaryExpr {
     @Override
     public String toString() {
         if (memberAccess != null) {
-            return String.format("%s = %s", memberAccess, value);
+            return String.format("%s %s %s", memberAccess, ASTBinaryExpr.opToString(op), value);
         } else {
-            return String.format("%s = %s", variable, value);
+            return String.format("%s %s %s", variable, ASTBinaryExpr.opToString(op), value);
         }
     }
 }

--- a/tests/increment.lj
+++ b/tests/increment.lj
@@ -1,0 +1,32 @@
+intIntIncr() {
+    a = 5
+    a += 3
+    a -= 2
+    return a
+}
+
+intDoubleIncr() {
+    a = 5
+    a += 0.5
+    a -= 1.5
+    return a
+}
+
+doubleIntIncr() {
+    a = 5.5
+    a += 2
+    a -= 1
+    return a
+}
+
+doubleDoubleIncr() {
+    a = 5.5
+    a += 2.5
+    a -= 1.5
+    return a
+}
+
+test intIntIncr() == 6
+test intDoubleIncr() == 4.0
+test doubleIntIncr() == 6.5
+test doubleDoubleIncr() == 6.5

--- a/tests/outputs/increment.exp
+++ b/tests/outputs/increment.exp
@@ -1,0 +1,15 @@
+Warning: This program does not contain a main() function and will not be run
+[36m╷[0m
+[36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
+[36m│  └─[0m [36mMain[0m [32m✔[0m
+[36m│     ├─[0m [34mtest0()[0m [32m✔[0m
+[36m│     ├─[0m [34mtest1()[0m [32m✔[0m
+[36m│     ├─[0m [34mtest2()[0m [32m✔[0m
+[36m│     └─[0m [34mtest3()[0m [32m✔[0m
+
+[         4 tests found           ]
+[         0 tests skipped         ]
+[         4 tests started         ]
+[         0 tests aborted         ]
+[         4 tests successful      ]
+[         0 tests failed          ]


### PR DESCRIPTION
Previously increments were being treated as assignments, causing the old value of a variable to be overwritten by the increment value. This fixes the issue and adds a test file along with correct output.