### PR TITLE
Add keys() method to LJMap

### DIFF
--- a/ljwrappers/src/main/java/wrappers/LJMap.java
+++ b/ljwrappers/src/main/java/wrappers/LJMap.java
@@ -2,6 +2,7 @@ package wrappers;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class LJMap<K, V> extends HashMap<K, V> {
     private static final long serialVersionUID = 1L;
@@ -16,5 +17,9 @@ public class LJMap<K, V> extends HashMap<K, V> {
 
     public boolean contains(K key) {
         return containsKey(key);
+    }
+
+    public LJSet<K> keys() {
+        return new LJSet<>(keySet());
     }
 }

--- a/src/main/java/com/github/lessjava/types/ast/ASTClass.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTClass.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import com.github.lessjava.types.inference.HMType;
 import com.github.lessjava.types.inference.impl.HMTypeBase;
+import com.github.lessjava.types.inference.impl.HMTypeSet;
 import com.github.lessjava.types.inference.impl.HMTypeVar;
 
 public class ASTClass extends ASTNode {
@@ -73,6 +74,7 @@ public class ASTClass extends ASTNode {
                 add("get", new HMTypeVar());
                 add("contains", HMTypeBase.BOOL);
                 add("size", HMTypeBase.INT);
+                add("keys", new HMTypeSet(new HMTypeVar()));
             }
 
             public void add(String name, HMType type) {

--- a/src/main/java/com/github/lessjava/types/ast/ASTMap.java
+++ b/src/main/java/com/github/lessjava/types/ast/ASTMap.java
@@ -10,6 +10,9 @@ public class ASTMap extends ASTCollection {
 
     @Override
     public String toString() {
+        if(!(type instanceof HMTypeMap)) {
+            return "ASTMap";
+        }
         StringBuilder initialization = new StringBuilder();
         StringBuilder entries = new StringBuilder();
 

--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTInferTypes.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTInferTypes.java
@@ -392,6 +392,10 @@ public class LJASTInferTypes extends LJAbstractAssignTypes {
                             requireArgs(node, 0, arguments);
                             node.funcCall.type = HMTypeBase.INT;
                             break;
+                        case "keys":
+                            requireArgs(node, 0, arguments);
+                            node.funcCall.type = new HMTypeSet(keyType);
+                            break;
                         default:
                             addError(node, "Method does not exist");
                     }

--- a/src/main/java/com/github/lessjava/visitor/impl/LJGenerateJava.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJGenerateJava.java
@@ -400,9 +400,12 @@ public class LJGenerateJava extends LJDefaultASTVisitor {
     @Override
     public void preVisit(ASTForLoop node) {
         if (node.lowerBound == null) {
-            HMType cType = ((HMTypeCollection) node.upperBound.type).elementType;
-            String line = String.format("for (%s i : %s)", cType, node.upperBound);
-            addLine(node, line);
+            // If we're not in a concrete function the cast may fail
+            if(currentFunction != null && currentFunction.concrete) {
+                HMType cType = ((HMTypeCollection) node.upperBound.type).elementType;
+                String line = String.format("for (%s %s : %s)", cType, node.var.name, node.upperBound);
+                addLine(node, line);
+            }
         } else {
             String lowerBound = node.lowerBound == null ? "0" : node.lowerBound.toString();
             String upperBound = node.upperBound.toString();

--- a/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
@@ -302,7 +302,7 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
                 "%s$%s",
                 name,
                 arguments.stream()
-                         .map(a -> a.type.toString().replaceAll("<", "LAB").replaceAll(">", "RAB"))
+                         .map(a -> a.type.toString().replaceAll("<", "LAB").replaceAll(">", "RAB").replaceAll(", ", "\\$"))
                          .collect(Collectors.joining("$"))
             );
 

--- a/tests/mapFind.lj
+++ b/tests/mapFind.lj
@@ -1,0 +1,18 @@
+mapFind(map, value, err) {
+    for(k: map.keys()) {
+        if(map[k] == value) {
+            return k
+        }
+    }
+    return err
+}
+
+main() {
+    map = <"Hello": 5, "Bye": 3>
+    println(mapFind(map, 5, "FAILED"))
+    println(mapFind(map, 2, "FAILED"))
+}
+
+test mapFind(<"a": 3, "b": 2>, 2, "FAILED") == "b"
+test mapFind(<"a": 3, "b": 2>, 100, "FAILED") == "FAILED"
+test mapFind(<5: 3, 4: 2>, 10, -1) == -1

--- a/tests/outputs/mapFind.exp
+++ b/tests/outputs/mapFind.exp
@@ -1,0 +1,15 @@
+Hello
+FAILED
+[36m╷[0m
+[36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
+[36m│  └─[0m [36mMain[0m [32m✔[0m
+[36m│     ├─[0m [34mtest0()[0m [32m✔[0m
+[36m│     ├─[0m [34mtest1()[0m [32m✔[0m
+[36m│     └─[0m [34mtest2()[0m [32m✔[0m
+
+[         3 tests found           ]
+[         0 tests skipped         ]
+[         3 tests started         ]
+[         0 tests aborted         ]
+[         3 tests successful      ]
+[         0 tests failed          ]


### PR DESCRIPTION
Adds a method to LJMaps that returns a set of keys. Also adds a sample program ```mapFind.lj``` which makes use of this method