### PR TITLE
Fix expected output for tests/mapFind

### DIFF
--- a/tests/outputs/mapFind.exp
+++ b/tests/outputs/mapFind.exp
@@ -1,5 +1,3 @@
-Hello
-FAILED
 [36m╷[0m
 [36m├─[0m [36mJUnit Jupiter[0m [32m✔[0m
 [36m│  └─[0m [36mMain[0m [32m✔[0m
@@ -13,3 +11,6 @@ FAILED
 [         0 tests aborted         ]
 [         3 tests successful      ]
 [         0 tests failed          ]
+
+Hello
+FAILED


### PR DESCRIPTION
Tests failed because the expected testing\running outputs of mapFind were in the wrong order. This should fix the build error in Travis.