### PR TITLE
Static analysis for method calls

### DIFF
--- a/src/main/java/com/github/lessjava/visitor/impl/LJASTInferTypes.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJASTInferTypes.java
@@ -480,9 +480,13 @@ public class LJASTInferTypes extends LJAbstractAssignTypes {
 
         if (node.invoker.type instanceof HMTypeClass) {
             HMTypeClass type = (HMTypeClass) node.invoker.type;
-            HMType returnType = ASTClass.nameClassMap.get(type.name).getMethod(node.funcCall.name).returnType;
+            ASTClass containingClass = ASTClass.nameClassMap.get(type.name);
 
-            node.type = unify(node, node.type, returnType);
+            if(containingClass.getMethod(node.funcCall.name) != null) {
+                HMType returnType = containingClass.getMethod(node.funcCall.name).returnType;
+
+                node.type = unify(node, node.type, returnType);
+            }
         }
 
         node.type = unify(node, node.type, node.funcCall.type);

--- a/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
+++ b/src/main/java/com/github/lessjava/visitor/impl/LJInstantiateFunctions.java
@@ -191,6 +191,15 @@ public class LJInstantiateFunctions extends LJAbstractAssignTypes {
 
         HMTypeClass type = (HMTypeClass) node.invoker.type;
         ASTClass containingClass = ASTClass.nameClassMap.get(type.name);
+        while(containingClass != null && containingClass.getMethod(node.funcCall.name) == null) {
+            containingClass = containingClass.parent;
+        }
+
+        if(containingClass == null) {
+            StaticAnalysis.addError(node, "Method " + node.funcCall.name + " not found for " + node.invoker.type);
+            return;
+        }
+
         ASTMethod m = containingClass.getMethod(node.funcCall.name);
 
         if (m != null && m.concrete) {

--- a/src/test/java/com/github/lessjava/visitor/impl/LJStaticAnalysisTest.java
+++ b/src/test/java/com/github/lessjava/visitor/impl/LJStaticAnalysisTest.java
@@ -563,4 +563,15 @@ class LJStaticAnalysisTest {
         assertValid(program);
     }
 
+    @Test
+    public void testMethodNotFound_invalid() {
+        String program =
+                CLASS_A +
+                "main() {\n" +
+                        "a = A()\n" +
+                        "a.badMethodCall()\n" +
+                "}\n";
+        assertInvalid(program);
+    }
+
 }


### PR DESCRIPTION
If a call is made to a method that doesn't exist, a static analysis error is generated. Tested by ```LJStaticAnalysisTest.testMethodNotFound_invalid```